### PR TITLE
Hwdev 2101 add driver component support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ $ catkin_make
 $ source devel/setup.bash
 $ rosrun mainboard_updator mainboard_updator <confirmed_firmware.bin> [reboot]
 ```
+## Update with legacy ROS system
+Please use [legacy](https://github.com/LexxPluss/LexxHard-MainBoard-Updator/tree/legacy) branch to update firmware with legacy ROS system.

--- a/catkin_ws/src/mainboard_updator/src/mainboard_updator.cpp
+++ b/catkin_ws/src/mainboard_updator/src/mainboard_updator.cpp
@@ -166,9 +166,9 @@ int main(int argc, char **argv)
 {
     ros::init(argc, argv, "mainboard_updator");
     ros::NodeHandle nh;
-    ros::Publisher pub_temp{nh.advertise<std_msgs::UInt8MultiArray>("/lexxhard/dfu_data", 10)};
+    ros::Publisher pub_temp{nh.advertise<std_msgs::UInt8MultiArray>("/global/lexxhard/dfu_data", 10)};
     pub = &pub_temp;
-    ros::Subscriber sub{nh.subscribe("/lexxhard/dfu_response", 10, callback)};
+    ros::Subscriber sub{nh.subscribe("/global/lexxhard/dfu_response", 10, callback)};
     sleep(1);
     ros::Rate loop_rate{100};
     packet.data.resize(260);


### PR DESCRIPTION
Ref: [HWDEV-2102](https://lexxpluss.atlassian.net/browse/HWDEV-2102)

This PR is motivated to add driver component support. If this PR is merged, we cannot use updator with legacy ROS system which don't have driver component. So After this PR merged,  I'll create a `legacy` branch whose commit hash is `4d13d42762044577f43dd1e5a7826ae87c80cee7` to work with legacy ROS system.

[HWDEV-2102]: https://lexxpluss.atlassian.net/browse/HWDEV-2102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ